### PR TITLE
feat: add native lazy loading for images

### DIFF
--- a/patterns/core/AddCartSuccessModal/Recommendations.js
+++ b/patterns/core/AddCartSuccessModal/Recommendations.js
@@ -1,17 +1,13 @@
-import { useRef } from 'react'
 import Slider from 'react-slick'
 import { NextArrow, PrevArrow, Heading } from '../..'
-import { useLazyLoading, useTranslation } from '../../../utils'
+import { useTranslation } from '../../../utils'
 import ProductTile from '../StreamPlacement/ProductTile'
 
 export default function Recommendations({ products = [] }) {
   const { t } = useTranslation()
-  const listRef = useRef(null)
-
-  useLazyLoading({ ref: listRef, dependency: products })
 
   return (
-    <div className="cart-modal__content--bottom" ref={listRef}>
+    <div className="cart-modal__content--bottom">
       <Heading>{t('RECOMMENDATION_HEADING')}</Heading>
 
       <Slider

--- a/patterns/core/Image/index.js
+++ b/patterns/core/Image/index.js
@@ -1,6 +1,5 @@
 import classnames from 'classnames'
-import { useRef } from 'react'
-import { useConfiguration, useLazyLoading } from '../../../utils'
+import { useConfiguration } from '../../../utils'
 import Preload from './Preload'
 
 /*
@@ -37,8 +36,6 @@ function Image(props) {
   } = props
 
   const { getImageLinks } = useConfiguration()
-  const wrapperRef = useRef(null)
-
   const imageLinks = getImageLinks(options)
 
   /**
@@ -51,28 +48,20 @@ function Image(props) {
 
   const wrapperClasses = classnames('image', className)
 
-  useLazyLoading({ ref: wrapperRef, dependency: options })
-
   let imgProps = {
     alt: alt,
     title: title,
+    ...(lazyload ? { loading: 'lazy' } : {}),
   }
 
   const fallbackSrc = imageLinks['desktop']
     ? imageLinks['desktop']
     : Object.values(imageLinks)[0]
 
-  if (lazyload) {
-    imgProps['data-src'] = fallbackSrc['origin']
-    imgProps[
-      'data-srcset'
-    ] = `${fallbackSrc['origin']} 1x, ${fallbackSrc['retina']} 2x`
-  } else {
-    imgProps['src'] = fallbackSrc['origin']
-    imgProps[
-      'srcSet'
-    ] = `${fallbackSrc['origin']} 1x, ${fallbackSrc['retina']} 2x`
-  }
+  imgProps['src'] = fallbackSrc['origin']
+  imgProps[
+    'srcSet'
+  ] = `${fallbackSrc['origin']} 1x, ${fallbackSrc['retina']} 2x`
 
   /**
    * Explicit check on the amount of generated <source> elements to avoid rendering
@@ -84,7 +73,7 @@ function Image(props) {
     <>
       <Preload preload={preload} options={options} imageLinks={imageLinks} />
 
-      <ElementWrapper ref={wrapperRef} className={wrapperClasses}>
+      <ElementWrapper className={wrapperClasses}>
         {shouldRenderSourceElements &&
           Object.entries(options).map((option) => {
             const [breakpoint, config] = option
@@ -92,17 +81,13 @@ function Image(props) {
             const src = imageLinks[breakpoint]['origin']
             const retinaSrc = imageLinks[breakpoint]['retina']
 
-            let sourceProps = {
-              media: config.media,
-            }
-
-            if (lazyload) {
-              sourceProps['data-srcset'] = `${src} 1x, ${retinaSrc} 2x`
-            } else {
-              sourceProps['srcSet'] = `${src} 1x, ${retinaSrc} 2x`
-            }
-
-            return <source key={breakpoint} {...sourceProps} />
+            return (
+              <source
+                key={breakpoint}
+                srcSet={`${src} 1x, ${retinaSrc} 2x`}
+                media={config.media}
+              />
+            )
           })}
 
         <img {...imgProps} />

--- a/patterns/core/ProductList/List.js
+++ b/patterns/core/ProductList/List.js
@@ -1,6 +1,5 @@
-import { useRef } from 'react'
 import classNames from 'classnames'
-import { GTM, useGlobalData, useLazyLoading } from '../../../utils'
+import { GTM, useGlobalData } from '../../../utils'
 import Banner from './Banner'
 import ProductTile from './ProductTile'
 import Pagination from './Pagination'
@@ -14,8 +13,6 @@ export default function List(props) {
     submitForms,
     isLoading = false,
   } = props
-  const listRef = useRef(null)
-  useLazyLoading({ ref: listRef, dependency: products })
 
   const { params = {}, searchResult } = useGlobalData()
   const { searchPhrase } = params
@@ -43,7 +40,7 @@ export default function List(props) {
   })
 
   return (
-    <div ref={listRef} className={classes}>
+    <div className={classes}>
       {products.map((entry, index) => {
         if (entry.isBanner) {
           return <Banner key={`banner.${entry.id}`} {...entry} />

--- a/patterns/core/ProductList/ProductImage.js
+++ b/patterns/core/ProductList/ProductImage.js
@@ -4,7 +4,7 @@ export default function ProductImage(product) {
   const {
     title = '',
     images = [],
-    activeVariant,
+    activeVariant = false,
     picture_url_main = '',
   } = product
 
@@ -14,31 +14,13 @@ export default function ProductImage(product) {
   if (!imageSource) {
     imageSource = picture_url_main
   }
-  {
-    /* TODO: Refactor once we use native lazy loading */
-  }
-  if (activeVariant) {
-    return (
-      <Image
-        className="product-item__image"
-        alt={title}
-        height="228"
-        lazyload={false}
-        options={{
-          desktop: {
-            source: imageSource,
-            height: 228,
-          },
-        }}
-      />
-    )
-  }
 
   return (
     <Image
       className="product-item__image"
       alt={title}
       height="228"
+      lazyload={activeVariant}
       options={{
         desktop: {
           source: imageSource,

--- a/patterns/core/ProductPlacement/ProductTile.js
+++ b/patterns/core/ProductPlacement/ProductTile.js
@@ -20,7 +20,7 @@ export default function ProductTile(props) {
     <article className="product-placement-item">
       <Link href={productDetailUrl}>
         <picture className="product-placement-item__image">
-          <img data-src={imageLink} alt={title} />
+          <img src={imageLink} alt={title} loading="lazy" />
         </picture>
 
         <Heading

--- a/patterns/core/ProductPlacement/index.js
+++ b/patterns/core/ProductPlacement/index.js
@@ -1,13 +1,8 @@
-import { useRef } from 'react'
 import ProductTile from './ProductTile'
 import { Heading, Copytext } from '../..'
-import { useLazyLoading } from '../../../utils'
 
 function ProductPlacement(props) {
   const { products = [], heading = '', text = '' } = props
-  const listRef = useRef(null)
-
-  useLazyLoading({ ref: listRef, dependency: products })
 
   if (products.length == 0) return null
 
@@ -18,7 +13,7 @@ function ProductPlacement(props) {
         {text && <Copytext dangerouslySetInnerHTML={{ __html: text }} />}
       </div>
 
-      <div ref={listRef} className="product-placement__list">
+      <div className="product-placement__list">
         {products.map((product) => (
           <ProductTile key={product.ean} {...product} />
         ))}

--- a/patterns/core/StreamPlacement/ProductTile.js
+++ b/patterns/core/StreamPlacement/ProductTile.js
@@ -25,7 +25,7 @@ export default function ProductTile(props) {
     <article className="stream-placement-item">
       <Link href={productDetailUrl}>
         <picture className="stream-placement-item__image">
-          <img data-src={productImage} alt={title} />
+          <img src={productImage} alt={title} loading="lazy" />
         </picture>
 
         <Heading

--- a/patterns/core/StreamPlacement/index.js
+++ b/patterns/core/StreamPlacement/index.js
@@ -1,13 +1,8 @@
-import { useRef } from 'react'
 import ProductTile from './ProductTile'
 import { Heading, Copytext } from '../..'
-import { useLazyLoading } from '../../../utils'
 
 function StreamPlacement(props) {
   const { products = [], heading = '', text = '' } = props
-  const listRef = useRef(null)
-
-  useLazyLoading({ ref: listRef, dependency: products })
 
   if (products.length == 0) return null
 
@@ -18,7 +13,7 @@ function StreamPlacement(props) {
         {text && <Copytext dangerouslySetInnerHTML={{ __html: text }} />}
       </div>
 
-      <div ref={listRef} className="stream-placement__list">
+      <div className="stream-placement__list">
         {products.map((product) => (
           <ProductTile key={product.ean} {...product} />
         ))}

--- a/patterns/core/TeaserDuo/image.js
+++ b/patterns/core/TeaserDuo/image.js
@@ -1,18 +1,14 @@
-import { useRef } from 'react'
-import { useConfiguration, useLazyLoading } from '../../../utils'
+import { useConfiguration } from '../../../utils'
 
 export default function Image(props) {
   const { getImageLink } = useConfiguration()
-  const pictureRef = useRef(null)
   const { src = '', alt = '' } = props
 
   const imageLink = getImageLink({ source: src, format: 'auto' })
 
-  useLazyLoading({ ref: pictureRef, dependency: src })
-
   return (
-    <picture ref={pictureRef} className="duo-teaser__image">
-      <img data-src={imageLink} alt={alt} />
+    <picture className="duo-teaser__image">
+      <img src={imageLink} alt={alt} loading="lazy" />
     </picture>
   )
 }

--- a/patterns/core/TeaserGrid/Tile.js
+++ b/patterns/core/TeaserGrid/Tile.js
@@ -44,17 +44,9 @@ export default function Tile(props) {
   return (
     <ConditionalLink href={link} fallbackElement="div" className={classes}>
       <picture>
-        <source
-          media="(max-width: 549px)"
-          data-srcset={imageLinkSmall}
-          srcSet={lazyLoadingDeactivated ? imageLinkSmall : null}
-        />
-        <source
-          media="(min-width: 550px)"
-          data-srcset={imageLinkLarge}
-          srcSet={lazyLoadingDeactivated ? imageLinkLarge : null}
-        />
-        <img alt={alt} />
+        <source media="(max-width: 549px)" srcSet={imageLinkSmall} />
+        <source media="(min-width: 550px)" srcSet={imageLinkLarge} />
+        <img alt={alt} loading={lazyLoadingDeactivated ? 'eager' : 'lazy'} />
       </picture>
 
       <Content {...content} link={link} />

--- a/patterns/core/TeaserGrid/index.js
+++ b/patterns/core/TeaserGrid/index.js
@@ -1,6 +1,4 @@
-import { useRef } from 'react'
 import classNames from 'classnames'
-import { useLazyLoading } from '../../../utils'
 import Tile from './Tile'
 
 function TeaserGrid(props) {
@@ -10,18 +8,11 @@ function TeaserGrid(props) {
     lazyLoadingDeactivated = false,
   } = props
   const { topRight, left, middle, bottomRight } = tiles
-  const sectionRef = useRef(null)
 
   const classes = classNames('teaser-grid', `teaser-grid--${variant}`)
 
-  useLazyLoading({
-    ref: sectionRef,
-    dependency: tiles,
-    active: !lazyLoadingDeactivated,
-  })
-
   return (
-    <section ref={sectionRef} className={classes}>
+    <section className={classes}>
       <Tile
         {...topRight}
         className="teaser-grid__tile--top-right"

--- a/patterns/core/TeaserHero/Image.js
+++ b/patterns/core/TeaserHero/Image.js
@@ -1,18 +1,14 @@
-import { useRef } from 'react'
-import { useConfiguration, useLazyLoading } from '../../../utils'
+import { useConfiguration } from '../../../utils'
 
 export default function Image(props) {
   const { getImageLink } = useConfiguration()
-  const pictureRef = useRef(null)
   const { src = '', alt = '' } = props
 
   const imageLink = getImageLink({ source: src, format: 'auto' })
 
-  useLazyLoading({ ref: pictureRef, dependency: src })
-
   return (
-    <picture ref={pictureRef} className="hero-teaser__image">
-      <img data-src={imageLink} alt={alt} />
+    <picture className="hero-teaser__image">
+      <img src={imageLink} alt={alt} loading="lazy" />
     </picture>
   )
 }

--- a/patterns/core/TeaserProducts/index.js
+++ b/patterns/core/TeaserProducts/index.js
@@ -1,25 +1,20 @@
-import { useRef } from 'react'
 import classNames from 'classnames'
 import {
   useTranslation,
-  useLazyLoading,
   useConfiguration,
   getProductDetailUrl,
 } from '../../../utils'
 import { Heading, Copytext, Button } from '../..'
 
 function TeaserProducts(props) {
-  const listRef = useRef(null)
   const { products = [], variant = 'white' } = props
-
-  useLazyLoading({ ref: listRef, dependency: products })
 
   if (products.length == 0) return null
 
   const classes = classNames('product-teaser', `product-teaser--${variant}`)
 
   return (
-    <section ref={listRef} className={classes}>
+    <section className={classes}>
       {products.map((product) => (
         <Teaser key={product.ean} {...product} />
       ))}
@@ -52,8 +47,9 @@ function Teaser(props) {
       <picture className="product-teaser__teaser-image">
         <img
           src={imageLink}
-          data-srcset={`${imageLink} 1x, ${imageLinkRetina} 2x`}
+          srcSet={`${imageLink} 1x, ${imageLinkRetina} 2x`}
           alt={title}
+          loading="lazy"
           height="228"
         />
       </picture>

--- a/patterns/core/TeaserSingle/index.js
+++ b/patterns/core/TeaserSingle/index.js
@@ -1,9 +1,7 @@
-import { useRef } from 'react'
-import { useConfiguration, useLazyLoading } from '../../../utils'
+import { useConfiguration } from '../../../utils'
 import { Heading, Copytext, Button, ConditionalLink } from '../..'
 
 function TeaserSingle(props) {
-  const pictureRef = useRef(null)
   const { getImageLink } = useConfiguration()
   const {
     image = {},
@@ -16,17 +14,15 @@ function TeaserSingle(props) {
 
   const imageLink = getImageLink({ source: image.src })
 
-  useLazyLoading({ ref: pictureRef, dependency: image.src })
-
   return (
     <section className="single-teaser">
       <ConditionalLink href={link} className="single-teaser__image">
-        <picture ref={pictureRef}>
-          {isLazyLoad ? (
-            <img data-src={imageLink} alt={image.alt} />
-          ) : (
-            <img src={imageLink} alt={image.alt} />
-          )}
+        <picture>
+          <img
+            src={imageLink}
+            alt={image.alt}
+            loading={isLazyLoad ? 'lazy' : 'eager'}
+          />
         </picture>
       </ConditionalLink>
 

--- a/utils/core/useLazyLoading/index.js
+++ b/utils/core/useLazyLoading/index.js
@@ -32,6 +32,10 @@ export default function useLazyLoading({
   customOptions = {},
   active = true,
 }) {
+  deprecationWarning(
+    'useLazyLoading is deprecated. Please use the native browser based lazy loading instead.'
+  )
+
   const defaultOptions = {
     root: null,
     rootMargin: '0px',
@@ -87,6 +91,9 @@ export default function useLazyLoading({
           })
       }
     },
-    [ref, dependency, options]
+    [ref, dependency, options, active]
   )
 }
+
+const deprecationWarning =
+  process.env.NODE_ENV !== 'production' ? console.warn : () => {}


### PR DESCRIPTION
## Description
In the previous implementation, lazy loading in JavaScript resulted in delayed image loading after hydration, negatively impacting web vital scores. To resolve this issue, I've implemented native lazy image loading, which is now well-supported across all browsers (refer to [caniuse.com/loading-lazy-attr](https://caniuse.com/loading-lazy-attr)).

## Changes Made
- Replaced JS-based lazy loading with native lazy image loading in all core components
- Add deprecation warning to the `useLazyLoading` hook


## Future Considerations
In the future, we should use the Next.js Image component.